### PR TITLE
bitbucket.org/kardianos/osext has moved to github.com/kardianos/osext

### DIFF
--- a/check/check.go
+++ b/check/check.go
@@ -9,8 +9,8 @@ import (
 	"io/ioutil"
 	"runtime"
 
-	"bitbucket.org/kardianos/osext"
 	"github.com/getlantern/go-update"
+	"github.com/kardianos/osext"
 )
 
 type Initiative string

--- a/update.go
+++ b/update.go
@@ -113,7 +113,7 @@ while outputting a progress meter and supports resuming partial downloads.
 package update
 
 import (
-	"bitbucket.org/kardianos/osext"
+	"github.com/kardianos/osext"
 	"bytes"
 	"crypto"
 	"crypto/rsa"


### PR DESCRIPTION
Backport of the fix from inconshreveable/go-update#15
